### PR TITLE
[fix] NewMapsEnableWorldPartitionStreaming 설정 끔

### DIFF
--- a/SPT/Config/DefaultEngine.ini
+++ b/SPT/Config/DefaultEngine.ini
@@ -90,3 +90,6 @@ ConnectionType=USBOnly
 bUseManualIPAddress=False
 ManualIPAddress=
 
+[/Script/Engine.WorldPartitionSettings]
+bNewMapsEnableWorldPartitionStreaming=False
+


### PR DESCRIPTION
NewMapsEnableWorldPartitionStreaming 은 월드에 있는 모든 액터를 하나의 파일로 만들어 관리하는 Actor Per File 기능을 필수로 요구하므로 LFS 환경에서 적절하지 않다고 판단, 설정을 껐습니다