### PR TITLE
[gitfix] LFS가 작동하도록 깃어트리뷰트 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,10 @@
 # *.tga   filter=lfs diff=lfs merge=lfs -text
 # *.exr   filter=lfs diff=lfs merge=lfs -text
 
+[attr]lock filter=lfs diff=lfs merge=binary -text lockable
+[attr]lockonly lockable
+[attr]lfs filter=lfs diff=lfs merge=binary -text
+[attr]lfstext filter=lfs diff=lfstext merge=lfstext -text
 # Unreal Engine file types.
 *.uasset lfs
 *.umap lfs


### PR DESCRIPTION
깃어트리뷰트의 잘못된 내용을 수정했습니다.

잘못된 내용으로 LFS가 사용되지 않고 있었는데, LFS를 사용하도록 내용을 추가해서 사용되도록 수정했습니다.