### PR TITLE
[add, update] 훈련장 레벨 추가 및 관련 클래스 추가

### DIFF
--- a/SPT/Content/Blueprints/GameModes/BP_PracticeRangeGameMode.uasset
+++ b/SPT/Content/Blueprints/GameModes/BP_PracticeRangeGameMode.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:286057ceeedb73fb1b3d8c4ee3b875589b567e215cf520fd7146b31c8e839df0
+size 20489

--- a/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
+++ b/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:480e9ec0d110ab97e1779384aadb77f59d366d848defa0fa3c46eded8eeb74e7
+size 20608

--- a/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
+++ b/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:480e9ec0d110ab97e1779384aadb77f59d366d848defa0fa3c46eded8eeb74e7
-size 20608
+oid sha256:1bccbe577be9c61dc1d95dbceccabb62253e134aa7215bd7f8d4b6bec00f81c8
+size 20762

--- a/SPT/Content/Maps/PracticeRangeLevel.umap
+++ b/SPT/Content/Maps/PracticeRangeLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:929b2ed23fa555938e94e26ae696ec2a6df17b28829ee786bf8a4498fad55782
-size 45892
+oid sha256:b7c900d0edd2bd20f14a0f450e0fe917fbf3e16446e6e2f2d18b79706b7a5d74
+size 46152

--- a/SPT/Content/Maps/PracticeRangeLevel.umap
+++ b/SPT/Content/Maps/PracticeRangeLevel.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929b2ed23fa555938e94e26ae696ec2a6df17b28829ee786bf8a4498fad55782
+size 45892

--- a/SPT/Source/SPT/Characters/BaseCharacter.cpp
+++ b/SPT/Source/SPT/Characters/BaseCharacter.cpp
@@ -1,0 +1,33 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "BaseCharacter.h"
+#include "GameFramework/CharacterMovementComponent.h"
+
+ABaseCharacter::ABaseCharacter()
+{
+	PrimaryActorTick.bCanEverTick = true;
+
+	NormalSpeed = 600.0f;
+	SprintSpeedMultiplier = 1.5f;
+	SprintSpeed = NormalSpeed * SprintSpeedMultiplier;
+
+	GetCharacterMovement()->MaxWalkSpeed = NormalSpeed;
+
+	// 앉기 기능 설정
+	GetCharacterMovement()->NavAgentProps.bCanCrouch = true;
+	// 앉기 시 현재 앉기 애니메이션에 맞는 절반 높이 설정
+	GetCharacterMovement()->SetCrouchedHalfHeight(65.f);
+}
+
+void ABaseCharacter::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void ABaseCharacter::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}

--- a/SPT/Source/SPT/Characters/BaseCharacter.h
+++ b/SPT/Source/SPT/Characters/BaseCharacter.h
@@ -1,0 +1,38 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Character.h"
+#include "BaseCharacter.generated.h"
+
+UCLASS()
+class SPT_API ABaseCharacter : public ACharacter
+{
+	GENERATED_BODY()
+
+public:
+	ABaseCharacter();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void Tick(float DeltaTime) override;
+
+protected:
+	// 기본 최대 체력
+	float MaxHP;
+	// 현재 체력
+	float HP;
+
+	// 기본 걷기 속도
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
+	float NormalSpeed;
+	// 기본 걷기 속도 대비 몇 배로 빠르게 달릴지 결정
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
+	float SprintSpeedMultiplier;
+	// 실제 달리기 속도
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
+	float SprintSpeed;
+};

--- a/SPT/Source/SPT/Characters/SPTPlayerCharacter.cpp
+++ b/SPT/Source/SPT/Characters/SPTPlayerCharacter.cpp
@@ -25,16 +25,6 @@ ASPTPlayerCharacter::ASPTPlayerCharacter()
 
 	CameraComp = CreateDefaultSubobject<UCameraComponent>(TEXT("Camera"));
 	CameraComp->SetupAttachment(SpringArmComp);
-
-    NormalSpeed = 600.0f;
-    SprintSpeedMultiplier = 1.5f;
-    SprintSpeed = NormalSpeed * SprintSpeedMultiplier;
-
-    GetCharacterMovement()->MaxWalkSpeed = NormalSpeed;
-    // 앉기 기능 설정
-    GetCharacterMovement()->NavAgentProps.bCanCrouch = true;
-    // 앉기 시 현재 앉기 애니메이션에 맞는 절반 높이 설정
-    GetCharacterMovement()->SetCrouchedHalfHeight(65.f);
 }
 
 void ASPTPlayerCharacter::BeginPlay()

--- a/SPT/Source/SPT/Characters/SPTPlayerCharacter.h
+++ b/SPT/Source/SPT/Characters/SPTPlayerCharacter.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "GameFramework/Character.h"
+#include "BaseCharacter.h"
 #include "SPTPlayerCharacter.generated.h"
 
 class USpringArmComponent;
@@ -12,7 +12,7 @@ class UCameraComponent;
 struct FInputActionValue;
 
 UCLASS()
-class SPT_API ASPTPlayerCharacter : public ACharacter
+class SPT_API ASPTPlayerCharacter : public ABaseCharacter
 {
 	GENERATED_BODY()
 
@@ -51,14 +51,4 @@ private:
 	TObjectPtr<USpringArmComponent> SpringArmComp;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Camera", meta = (AllowPrivateAccess = true))
 	TObjectPtr<UCameraComponent> CameraComp;
-
-	// 기본 걷기 속도
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
-	float NormalSpeed;
-	// 기본 걷기 속도 대비 몇 배로 빠르게 달릴지 결정
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
-	float SprintSpeedMultiplier;
-	// 실제 달리기 속도
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))
-	float SprintSpeed;
 };

--- a/SPT/Source/SPT/GameModes/PracticeRangeGameMode.cpp
+++ b/SPT/Source/SPT/GameModes/PracticeRangeGameMode.cpp
@@ -1,0 +1,9 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PracticeRangeGameMode.h"
+
+APracticeRangeGameMode::APracticeRangeGameMode()
+{
+
+}

--- a/SPT/Source/SPT/GameModes/PracticeRangeGameMode.h
+++ b/SPT/Source/SPT/GameModes/PracticeRangeGameMode.h
@@ -1,0 +1,19 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameMode.h"
+#include "PracticeRangeGameMode.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SPT_API APracticeRangeGameMode : public AGameMode
+{
+	GENERATED_BODY()
+	
+public:
+	APracticeRangeGameMode();
+};

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PracticeRangeGameState.h"
+

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameState.h"
+#include "PracticeRangeGameState.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SPT_API APracticeRangeGameState : public AGameState
+{
+	GENERATED_BODY()
+	
+};

--- a/SPT/Source/SPT/SPT.Build.cs
+++ b/SPT/Source/SPT/SPT.Build.cs
@@ -14,7 +14,8 @@ public class SPT : ModuleRules
 			Path.Combine(ModuleDirectory, "Characters"), 
 			Path.Combine(ModuleDirectory, "Controllers"), 
 			Path.Combine(ModuleDirectory, "GameModes"),
-			Path.Combine(ModuleDirectory, "AnimInstances")
+			Path.Combine(ModuleDirectory, "AnimInstances"),
+			Path.Combine(ModuleDirectory, "GameStates")
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });


### PR DESCRIPTION
플레이어 캐릭터의 부모 클래스 생성 및 체력 관련 변수 추가
이동속도 설정 및 앉기 설정을 부모 클래스에서 설정하도록 변경

Build.cs의 PublicIncludePaths에 게임 스테이트 폴더 설정

훈련장 레벨 추가

훈련장 레벨에 게임모드 오버라이드
 - 플레이어 캐릭터 적용
 - 플레이어 컨트롤러 적용
 - 게임 스테이트 적용