### PR TITLE
[add, update] AI를 스폰할 불륨 추가 및 AI 스폰 기능 추가

### DIFF
--- a/SPT/Content/Blueprints/GameModes/BP_PracticeRangeGameMode.uasset
+++ b/SPT/Content/Blueprints/GameModes/BP_PracticeRangeGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:286057ceeedb73fb1b3d8c4ee3b875589b567e215cf520fd7146b31c8e839df0
-size 20489
+oid sha256:56faf308438c38e2427f77fd73e3990a42b789c5c5f16ce694423ed1ba78ec57
+size 21923

--- a/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
+++ b/SPT/Content/Blueprints/GameStates/BP_PracticeRangeGameState.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bccbe577be9c61dc1d95dbceccabb62253e134aa7215bd7f8d4b6bec00f81c8
-size 20762
+oid sha256:67e001b2120357d4565a53591722c64c52f39ecc5911669ae6b2f76756c14c98
+size 21137

--- a/SPT/Content/Blueprints/SpawnVolumes/BP_AISpawnVolume.uasset
+++ b/SPT/Content/Blueprints/SpawnVolumes/BP_AISpawnVolume.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e159f7f916ce4abd48efa1d28b160992ee8b212ed260c21fc99975c7b04b8351
+size 23913

--- a/SPT/Content/Maps/PracticeRangeLevel.umap
+++ b/SPT/Content/Maps/PracticeRangeLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7c900d0edd2bd20f14a0f450e0fe917fbf3e16446e6e2f2d18b79706b7a5d74
-size 46152
+oid sha256:056a12ed85a4a0527f08d005bb7a0ee05feb98073c0f41e7d82911161208b78e
+size 48348

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
@@ -2,4 +2,44 @@
 
 
 #include "PracticeRangeGameState.h"
+#include "Kismet/GameplayStatics.h"
+#include "AISpawnVolume.h"
 
+APracticeRangeGameState::APracticeRangeGameState()
+{
+    // ProficiencyTest에서 소환할 AI 수
+    ProficiencyTestSpawnAICount = 10;
+}
+
+void APracticeRangeGameState::BeginPlay()
+{
+	Super::BeginPlay();
+
+    // 스폰 불륨 찾기
+    TArray<AActor*> FoundVolumes;
+    UGameplayStatics::GetAllActorsOfClass(GetWorld(), AAISpawnVolume::StaticClass(), FoundVolumes);
+
+    for (AActor* Found : FoundVolumes)
+    {
+        // 찾은 액터가 ProficiencyTesting용 스폰 불륨이라면
+        if (Found->ActorHasTag("ProficiencyTest"))
+        {
+            ProficiencyTestSpawnVolume = Cast<AAISpawnVolume>(Found);
+        }
+    }
+
+    // 테스트 코드
+	ProficiencyTestingStart(ProficiencyTestSpawnAICount);
+}
+
+void APracticeRangeGameState::ProficiencyTestingStart(int32 SpawnCount)
+{
+    // 스폰해야하는 횟수만큼 반복
+	for (int32 i = 0; i < SpawnCount; ++i)
+	{
+        if (ProficiencyTestSpawnVolume)
+        {
+            ProficiencyTestSpawnVolume->SpawnAI();
+        }
+	}
+}

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
@@ -6,12 +6,24 @@
 #include "GameFramework/GameState.h"
 #include "PracticeRangeGameState.generated.h"
 
-/**
- * 
- */
+class AAISpawnVolume;
+
 UCLASS()
 class SPT_API APracticeRangeGameState : public AGameState
 {
 	GENERATED_BODY()
 	
+public:
+	APracticeRangeGameState();
+
+protected:
+	virtual void BeginPlay() override;
+
+	// 숙련도 테스트 기능 시작
+	void ProficiencyTestingStart(int32 SpawnCount);
+
+private:
+	int32 ProficiencyTestSpawnAICount;
+
+	TObjectPtr<AAISpawnVolume> ProficiencyTestSpawnVolume;
 };

--- a/SPT/Source/SPT/SPT.Build.cs
+++ b/SPT/Source/SPT/SPT.Build.cs
@@ -15,7 +15,8 @@ public class SPT : ModuleRules
 			Path.Combine(ModuleDirectory, "Controllers"), 
 			Path.Combine(ModuleDirectory, "GameModes"),
 			Path.Combine(ModuleDirectory, "AnimInstances"),
-			Path.Combine(ModuleDirectory, "GameStates")
+			Path.Combine(ModuleDirectory, "GameStates"),
+			Path.Combine(ModuleDirectory, "SpawnVolumes")
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });

--- a/SPT/Source/SPT/SpawnVolumes/AISpawnVolume.cpp
+++ b/SPT/Source/SPT/SpawnVolumes/AISpawnVolume.cpp
@@ -1,0 +1,57 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AISpawnVolume.h"
+#include "Components/BoxComponent.h"
+#include "GameFramework/Character.h"
+
+AAISpawnVolume::AAISpawnVolume()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	Scene = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(Scene);
+
+	SpawningBox = CreateDefaultSubobject<UBoxComponent>(TEXT("SpawningBox"));
+	SpawningBox->SetupAttachment(Scene);
+}
+
+void AAISpawnVolume::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void AAISpawnVolume::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+FVector AAISpawnVolume::GetRandomXYPointInVolume() const
+{
+	// 박스 컴포넌트의 스케일된 Extent, 즉 x/y/z 방향으로 반지름(절반 길이)을 구함
+	FVector BoxExtent = SpawningBox->GetScaledBoxExtent();
+	FVector BoxOrigin = SpawningBox->GetComponentLocation();
+
+	FVector Pointlocation = BoxOrigin + FVector(
+		FMath::FRandRange(-BoxExtent.X, BoxExtent.X),
+		FMath::FRandRange(-BoxExtent.Y, BoxExtent.Y),
+		-BoxExtent.Z);
+
+	return Pointlocation;
+}
+
+ACharacter* AAISpawnVolume::SpawnAI()
+{
+	// 현재 스폰시키는 클래스가 멤버변수로 있다.
+	// 나중에 데이터 테이블로 관리한다면 수정해야한다.
+	if (!SpawnAIClass) return nullptr;
+
+	FVector SpawnLocation = GetRandomXYPointInVolume();
+	FRotator SpawnRotation = GetActorRotation();
+	ACharacter* SpawnAI = GetWorld()->SpawnActor<ACharacter>(SpawnAIClass, SpawnLocation, SpawnRotation);
+
+	return SpawnAI;
+}
+

--- a/SPT/Source/SPT/SpawnVolumes/AISpawnVolume.h
+++ b/SPT/Source/SPT/SpawnVolumes/AISpawnVolume.h
@@ -1,0 +1,44 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "AISpawnVolume.generated.h"
+
+class UBoxComponent;
+
+UCLASS()
+class SPT_API AAISpawnVolume : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	AAISpawnVolume();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void Tick(float DeltaTime) override;
+
+public:
+	// 스폰 볼륨 내부에서 무작위 X,Y 좌표를 얻어오는 함수(Z축은 Volume의 최소값)
+	FVector GetRandomXYPointInVolume() const;
+
+	// AI를 스폰한다.
+	ACharacter* SpawnAI();
+
+protected:
+	// 임시 멤버 변수
+	// 추후 데이터 테이블로 스폰할 AI클래스들을 관리한다면 제거해야함
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Spawning")
+	TSubclassOf<ACharacter> SpawnAIClass;
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Spawning", meta = (AllowPrivateAccess = true))
+	USceneComponent* Scene;
+	// 스폰 영역을 담당할 박스 컴포넌트
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Spawning", meta = (AllowPrivateAccess = true))
+	UBoxComponent* SpawningBox;
+};


### PR DESCRIPTION
AI를 스폰할 범위를 의미하는 불륨 클래스 추가

불륨을 관리할 폴더 추가 및 Build.cs 수정

레벨에 게임 모드 오버라이드 재설정

게임이 시작 됐을 경우 게임 스테이트에서 불륨을 저장 및 호출을 통해 AI를 스폰하도록 구현 현재 AI가 아직 없는 관계로 플레이어 캐릭터를 스폰하도록 설정했음