### PR TITLE
[update] TakeDamage함수 구현 및 AI 리스폰 기능 구현 추가

### DIFF
--- a/SPT/Source/SPT/Characters/BaseCharacter.cpp
+++ b/SPT/Source/SPT/Characters/BaseCharacter.cpp
@@ -31,3 +31,28 @@ void ABaseCharacter::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 
 }
+
+float ABaseCharacter::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
+{
+	float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+
+	Health = FMath::Clamp(Health - ActualDamage, 0.0f, MaxHealth);
+	
+
+	if (Health <= 0.f)
+	{
+		OnDeath();
+	}
+
+	return 0.0f;
+}
+
+void ABaseCharacter::OnDeath()
+{
+	// 사망 후 로직
+	// 바인드 된 함수 호출
+	OnDethMulticastDelegate.Broadcast();
+
+	// 바인드 된 함수에 대해 연결 해제
+	OnDethMulticastDelegate.Clear();
+}

--- a/SPT/Source/SPT/Characters/BaseCharacter.h
+++ b/SPT/Source/SPT/Characters/BaseCharacter.h
@@ -6,6 +6,8 @@
 #include "GameFramework/Character.h"
 #include "BaseCharacter.generated.h"
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnDethMulticastDelegate);
+
 UCLASS()
 class SPT_API ABaseCharacter : public ACharacter
 {
@@ -21,10 +23,21 @@ public:
 	virtual void Tick(float DeltaTime) override;
 
 protected:
+	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser) override;
+
+	// 사망 처리 함수 (체력이 0 이하가 되었을 때 호출)
+	UFUNCTION(BlueprintCallable, Category = "Health")
+	virtual void OnDeath();
+
+public:
+	UPROPERTY(BlueprintAssignable, VisibleAnywhere, BlueprintCallable, Category = "Event")
+	FOnDethMulticastDelegate OnDethMulticastDelegate;
+
+protected:
 	// 기본 최대 체력
-	float MaxHP;
+	float MaxHealth;
 	// 현재 체력
-	float HP;
+	float Health;
 
 	// 기본 걷기 속도
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement", meta = (AllowPrivateAccess = true))

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.cpp
@@ -4,6 +4,7 @@
 #include "PracticeRangeGameState.h"
 #include "Kismet/GameplayStatics.h"
 #include "AISpawnVolume.h"
+#include "BaseCharacter.h"
 
 APracticeRangeGameState::APracticeRangeGameState()
 {
@@ -29,17 +30,37 @@ void APracticeRangeGameState::BeginPlay()
     }
 
     // 테스트 코드
-	ProficiencyTestingStart(ProficiencyTestSpawnAICount);
+    ProficiencyTestingStart();
 }
 
-void APracticeRangeGameState::ProficiencyTestingStart(int32 SpawnCount)
+void APracticeRangeGameState::ProficiencyTestingStart()
 {
+    // 특정 시간 안에 AI를 잡는 로직 구현
+    
     // 스폰해야하는 횟수만큼 반복
-	for (int32 i = 0; i < SpawnCount; ++i)
-	{
-        if (ProficiencyTestSpawnVolume)
+    for (int32 i = 0; i < ProficiencyTestSpawnAICount; ++i)
+    {
+        // AI 스폰
+        ProficiencyTestingAISpawn();
+    }
+}
+
+void APracticeRangeGameState::ProficiencyTestingAISpawn()
+{
+    if (ProficiencyTestSpawnVolume)
+    {
+        ABaseCharacter* BaseCharacter = Cast<ABaseCharacter>(ProficiencyTestSpawnVolume->SpawnAI());
+
+        if (BaseCharacter)
         {
-            ProficiencyTestSpawnVolume->SpawnAI();
+            // 스폰 시킨 AI가 사망된 후 스폰 함수 다시 호출
+            BaseCharacter->OnDethMulticastDelegate.AddDynamic(this, &APracticeRangeGameState::ProficiencyTestingAISpawn);
+            BaseCharacter->OnDethMulticastDelegate.AddDynamic(this, &APracticeRangeGameState::ProficiencyTestingAIKillCount);
         }
-	}
+    }
+}
+
+void APracticeRangeGameState::ProficiencyTestingAIKillCount()
+{
+    // AI가 처치됐다면 UI에 반영하는 로직
 }

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
@@ -20,7 +20,13 @@ protected:
 	virtual void BeginPlay() override;
 
 	// 숙련도 테스트 기능 시작
-	void ProficiencyTestingStart(int32 SpawnCount);
+	void ProficiencyTestingStart();
+	// 숙련도 테스트 기능을 위한 AI 스폰
+	UFUNCTION()
+	void ProficiencyTestingAISpawn();
+	// 숙련도 테스트 기능을 위한 킬 카운트
+	UFUNCTION()
+	void ProficiencyTestingAIKillCount();
 
 private:
 	int32 ProficiencyTestSpawnAICount;

--- a/SPT/Source/SPT/SpawnVolumes/SplineAISpawnPoint.cpp
+++ b/SPT/Source/SPT/SpawnVolumes/SplineAISpawnPoint.cpp
@@ -10,6 +10,8 @@ ASplineAISpawnPoint::ASplineAISpawnPoint()
 
 	Scene = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
 	SetRootComponent(Scene);
+
+	RespawnDelay = 1.f;
 }
 
 void ASplineAISpawnPoint::BeginPlay()
@@ -19,11 +21,11 @@ void ASplineAISpawnPoint::BeginPlay()
 	SpawnAI();
 }
 
-ACharacter* ASplineAISpawnPoint::SpawnAI()
+void ASplineAISpawnPoint::SpawnAI()
 {
 	// 현재 스폰시키는 클래스가 멤버변수로 있다.
 	// 나중에 데이터 테이블로 관리한다면 수정해야한다.
-	if (!SpawnAIClass) return nullptr;
+	if (!SpawnAIClass) return;
 
 	FVector SpawnLocation = GetActorLocation();
 	FRotator SpawnRotation = GetActorRotation();
@@ -32,7 +34,13 @@ ACharacter* ASplineAISpawnPoint::SpawnAI()
 	if (ASPTEnemyCharacter* SPTEnemyCharacter = Cast<ASPTEnemyCharacter>(SpawnAI))
 	{
 		SPTEnemyCharacter->PatrolRoute = this->PatrolRoute;
+		SPTEnemyCharacter->OnDethMulticastDelegate.AddDynamic(this, &ASplineAISpawnPoint::Respawn);
 	}
+}
 
-	return SpawnAI;
+void ASplineAISpawnPoint::Respawn()
+{
+	// AI를 특정 시간 후 리스폰 시키는 로직
+
+	GetWorldTimerManager().SetTimer(RespawnTimerHandle, this, &ASplineAISpawnPoint::SpawnAI, RespawnDelay, false);
 }

--- a/SPT/Source/SPT/SpawnVolumes/SplineAISpawnPoint.h
+++ b/SPT/Source/SPT/SpawnVolumes/SplineAISpawnPoint.h
@@ -21,15 +21,26 @@ protected:
 
 public:	
 	// AI를 스폰한다.
-	ACharacter* SpawnAI();
+	void SpawnAI();
+
+	// 스폰 시킨 AI가 사망된 후 호출되는 함수
+	UFUNCTION()
+	void Respawn();
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Spawning")
 	TSubclassOf<ACharacter> SpawnAIClass;
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Spawning")
 	TObjectPtr<APatrolRoute> PatrolRoute;
+	
+	// 리스폰 딜레이
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Spawning")
+	float RespawnDelay;
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Spawning", meta = (AllowPrivateAccess = true))
 	USceneComponent* Scene;
+
+	// 특정 시간 이후 리스폰시키는 타이머
+	FTimerHandle RespawnTimerHandle;
 };


### PR DESCRIPTION
ABaseCharacter 클래스에서 TakeDamage 함수를 통해 데미지 처리를 구현하였으며, 캐릭터의 체력이 0이 되면 OnDeath 함수를 호출하도록 했습니다.

델리게이트를 이용하여 OnDeath 함수가 호출될 때 바인딩된 함수가 있다면 함께 실행되도록 구현했습니다.

ProficiencyTestingAISpawn에서 스폰된 캐릭터가 처치되었을 때 호출되도록 리스폰을 담당하는 함수와 처치 처리를 담당하는 함수를 델리게이트에 바인딩했습니다.

ASplineAISpawnPoint에서 스폰된 캐릭터가 처치되었을 때 호출되도록 리스폰을 담당하는 함수를 델리게이트에 바인딩했습니다.