### PR TITLE
[bugfix] 공중에서 앉기 기능이 수행되지 않도록 수정

### DIFF
--- a/SPT/Source/SPT/Characters/SPTPlayerCharacter.cpp
+++ b/SPT/Source/SPT/Characters/SPTPlayerCharacter.cpp
@@ -312,6 +312,8 @@ void ASPTPlayerCharacter::StopSprint(const FInputActionValue& value)
 
 void ASPTPlayerCharacter::StartCrouch(const FInputActionValue& value)
 {
+    if (GetCharacterMovement()->IsFalling()) return;
+
     if (value.Get<bool>())
     {
         Crouch();
@@ -320,6 +322,8 @@ void ASPTPlayerCharacter::StartCrouch(const FInputActionValue& value)
 
 void ASPTPlayerCharacter::StopCrouch(const FInputActionValue& value)
 {
+    if (GetCharacterMovement()->IsFalling()) return;
+
     if (!value.Get<bool>())
     {
         UnCrouch();


### PR DESCRIPTION
앉기 입력시 캐릭터가 공중에 떠있는지 확인하고 떠있는 경우 리턴하도록 수정