### PR TITLE
[add, update] 훈련장 AI 사격 기능 시간 제한 및 점수 구현

### DIFF
--- a/SPT/Content/Blueprints/Actors/BP_PracticeScoreBoard.uasset
+++ b/SPT/Content/Blueprints/Actors/BP_PracticeScoreBoard.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4486c872cc1c3673bc6477dd3f5adb4a0a630b0ef7bee759c60327c5034b265b
+size 33813

--- a/SPT/Content/Blueprints/Actors/BP_PracticeTestTrigger.uasset
+++ b/SPT/Content/Blueprints/Actors/BP_PracticeTestTrigger.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8b0297e0314f2ba5dea2862b3de36ed8b814f060a15fe0c62314806756df5bc
+size 24043

--- a/SPT/Content/Blueprints/BP_PracticeScoreBoard.uasset
+++ b/SPT/Content/Blueprints/BP_PracticeScoreBoard.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb947a4a4d887031152598cf44e1f83b5eba7e6c3be2e090bcd72b8622ab0797
+size 2624

--- a/SPT/Content/Blueprints/Characters/BP_RandomMoveEnemy.uasset
+++ b/SPT/Content/Blueprints/Characters/BP_RandomMoveEnemy.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:804f11c0490bf7d0335049502298419dd82192dc4923d3ba7dd1da9d50c17d18
-size 36299
+oid sha256:5e9ae2daa7478d003d66359e9a3ad3fd94b12054ee03739d9741512e3f39ef8a
+size 36453

--- a/SPT/Content/Blueprints/UserWidget/BP_PracticeSocre.uasset
+++ b/SPT/Content/Blueprints/UserWidget/BP_PracticeSocre.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f4f10794559671d987d5488daf598d8e595ea94b83289733a9480ed4540ed8
+size 37991

--- a/SPT/Source/SPT/Actors/PracticeScoreBoard.cpp
+++ b/SPT/Source/SPT/Actors/PracticeScoreBoard.cpp
@@ -1,0 +1,131 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PracticeScoreBoard.h"
+#include "Components/WidgetComponent.h"
+#include "Components/TextBlock.h"
+
+APracticeScoreBoard::APracticeScoreBoard()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	Scene = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(Scene);
+
+	StaticMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
+	StaticMesh->SetupAttachment(Scene);
+
+	ScoreWidget = CreateDefaultSubobject<UWidgetComponent>(TEXT("ScoreWidget"));
+	ScoreWidget->SetupAttachment(StaticMesh);
+}
+
+void APracticeScoreBoard::BeginPlay()
+{
+	Super::BeginPlay();
+	
+	RemainingTime = 0.f;
+	Score = 0;
+}
+
+void APracticeScoreBoard::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+void APracticeScoreBoard::StartScoreBoard(float Time)
+{
+	// 값 초기화
+	RemainingTime = Time;
+	Score = 0;
+
+	// UI 갱신
+	if (ScoreWidget)
+	{
+		UUserWidget* ScoreWidgetInstance = ScoreWidget->GetUserWidgetObject();
+		if (ScoreWidgetInstance)
+		{
+			if (UTextBlock* RemainingTimeTextBlock = Cast<UTextBlock>(ScoreWidgetInstance->GetWidgetFromName(TEXT("RemainingTimeTextBlock"))))
+			{
+				RemainingTimeTextBlock->SetText(FText::FromString(FString::Printf(TEXT("%d"), FMath::FloorToInt(RemainingTime))));
+			}
+
+			if (UTextBlock* ScoreTextBlock = Cast<UTextBlock>(ScoreWidgetInstance->GetWidgetFromName(TEXT("ScoreTextBlock"))))
+			{
+				ScoreTextBlock->SetText(FText::FromString(FString::Printf(TEXT("%d"), Score)));
+			}
+		}
+	}
+
+	// 타이머 시작
+	GetWorldTimerManager().SetTimer(ScoreBoardTimerHandle, this, &APracticeScoreBoard::ReduceRemainingTime, 1.f, false);
+}
+
+void APracticeScoreBoard::EndScoreBoard()
+{
+	// UI 갱신
+	if (ScoreWidget)
+	{
+		UUserWidget* ScoreWidgetInstance = ScoreWidget->GetUserWidgetObject();
+		if (ScoreWidgetInstance)
+		{
+			if (UTextBlock* RemainingTimeTextBlock = Cast<UTextBlock>(ScoreWidgetInstance->GetWidgetFromName(TEXT("RemainingTimeTextBlock"))))
+			{
+				RemainingTimeTextBlock->SetText(FText::FromString(FString::Printf(TEXT("0"))));
+			}
+		}
+	}
+
+	GetWorldTimerManager().ClearTimer(ScoreBoardTimerHandle);
+	OnPracticeTestEndDelegate.Clear();
+}
+
+void APracticeScoreBoard::ReduceRemainingTime()
+{
+	// 남은 시간 감소
+	--RemainingTime;
+
+	// UI 갱신
+	if (ScoreWidget)
+	{
+		UUserWidget* ScoreWidgetInstance = ScoreWidget->GetUserWidgetObject();
+		if (ScoreWidgetInstance)
+		{
+			if (UTextBlock* RemainingTimeTextBlock = Cast<UTextBlock>(ScoreWidgetInstance->GetWidgetFromName(TEXT("RemainingTimeTextBlock"))))
+			{
+				RemainingTimeTextBlock->SetText(FText::FromString(FString::Printf(TEXT("%d"), FMath::FloorToInt(RemainingTime))));
+			}
+		}
+	}
+
+	// 시간이 남았다면 반복
+	if (RemainingTime > 0.f)
+	{
+		GetWorldTimerManager().SetTimer(ScoreBoardTimerHandle, this, &APracticeScoreBoard::ReduceRemainingTime, 1.f, false);
+	}
+	// 남은 시간이 없다면 바인딩된 함수 호출
+	else
+	{
+		OnPracticeTestEndDelegate.Broadcast();
+	}
+}
+
+void APracticeScoreBoard::AddScore()
+{
+	// 점수 변경
+	++Score;
+
+	// UI 갱신
+	if (ScoreWidget)
+	{
+		UUserWidget* ScoreWidgetInstance = ScoreWidget->GetUserWidgetObject();
+		if (ScoreWidgetInstance)
+		{
+			if (UTextBlock* ScoreTextBlock = Cast<UTextBlock>(ScoreWidgetInstance->GetWidgetFromName(TEXT("ScoreTextBlock"))))
+			{
+				ScoreTextBlock->SetText(FText::FromString(FString::Printf(TEXT("%d"), Score)));
+			}
+		}
+	}
+}
+

--- a/SPT/Source/SPT/Actors/PracticeScoreBoard.h
+++ b/SPT/Source/SPT/Actors/PracticeScoreBoard.h
@@ -1,0 +1,56 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "PracticeScoreBoard.generated.h"
+
+class UWidgetComponent;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPracticeTestEndDelegate);
+
+UCLASS()
+class SPT_API APracticeScoreBoard : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	APracticeScoreBoard();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void Tick(float DeltaTime) override;
+
+public:
+	void StartScoreBoard(float Time);
+
+	void EndScoreBoard();
+
+	UFUNCTION()
+	void AddScore();
+
+private:
+	void ReduceRemainingTime();
+
+public:
+	UPROPERTY(BlueprintAssignable, VisibleAnywhere, BlueprintCallable, Category = "Event")
+	FOnPracticeTestEndDelegate OnPracticeTestEndDelegate;
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> Scene;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> StaticMesh;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UWidgetComponent> ScoreWidget;
+
+	FTimerHandle ScoreBoardTimerHandle;
+
+	// 남은 시간
+	float RemainingTime;
+	// 현재 점수
+	int Score;
+};

--- a/SPT/Source/SPT/Actors/PracticeTestTrigger.cpp
+++ b/SPT/Source/SPT/Actors/PracticeTestTrigger.cpp
@@ -1,0 +1,58 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PracticeTestTrigger.h"
+#include "Components/BoxComponent.h"
+#include "PracticeRangeGameState.h"
+
+APracticeTestTrigger::APracticeTestTrigger()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	Scene = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(Scene);
+
+	Collision = CreateDefaultSubobject<UBoxComponent>(TEXT("Collision"));
+	Collision->SetupAttachment(Scene);
+	// 폰만 오버랩되도록 설정
+	Collision->SetCollisionProfileName(TEXT("OverlapOnlyPawn"));
+
+	// Overlap 이벤트 바인딩
+	Collision->OnComponentBeginOverlap.AddDynamic(this, &APracticeTestTrigger::OnBeginOverlap);
+	Collision->OnComponentEndOverlap.AddDynamic(this, &APracticeTestTrigger::OnEndOverlap);
+}
+
+void APracticeTestTrigger::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void APracticeTestTrigger::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+void APracticeTestTrigger::OnBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+	if (OtherActor)
+	{
+		if (APracticeRangeGameState* PracticeRangeGameState = GetWorld()->GetGameState<APracticeRangeGameState>())
+		{
+			PracticeRangeGameState->ProficiencyTestingStart();
+		}
+	}
+}
+
+void APracticeTestTrigger::OnEndOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex)
+{
+	if (OtherActor)
+	{
+		if (APracticeRangeGameState* PracticeRangeGameState = GetWorld()->GetGameState<APracticeRangeGameState>())
+		{
+			PracticeRangeGameState->ProficiencyTestingEnd();
+		}
+	}
+}
+

--- a/SPT/Source/SPT/Actors/PracticeTestTrigger.h
+++ b/SPT/Source/SPT/Actors/PracticeTestTrigger.h
@@ -1,0 +1,36 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "PracticeTestTrigger.generated.h"
+
+class UBoxComponent;
+
+UCLASS()
+class SPT_API APracticeTestTrigger : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	APracticeTestTrigger();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void Tick(float DeltaTime) override;
+
+protected:
+	UFUNCTION()
+	virtual void OnBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+	UFUNCTION()
+	virtual void OnEndOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex);
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> Scene;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UBoxComponent> Collision;
+};

--- a/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
+++ b/SPT/Source/SPT/GameStates/PracticeRangeGameState.h
@@ -7,6 +7,8 @@
 #include "PracticeRangeGameState.generated.h"
 
 class AAISpawnVolume;
+class APracticeScoreBoard;
+class APracticeTestTrigger;
 
 UCLASS()
 class SPT_API APracticeRangeGameState : public AGameState
@@ -19,17 +21,25 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
+public:
 	// 숙련도 테스트 기능 시작
 	void ProficiencyTestingStart();
+
+	// 숙련도 테스트 기능 끝내기
+	void ProficiencyTestingEnd();
+
+protected:
 	// 숙련도 테스트 기능을 위한 AI 스폰
 	UFUNCTION()
 	void ProficiencyTestingAISpawn();
-	// 숙련도 테스트 기능을 위한 킬 카운트
+	// 숙련도 테스트 기능이 끝난 경우 AI 제거
 	UFUNCTION()
-	void ProficiencyTestingAIKillCount();
+	void ProficiencyTestingAIDestroy();
 
 private:
 	int32 ProficiencyTestSpawnAICount;
 
 	TObjectPtr<AAISpawnVolume> ProficiencyTestSpawnVolume;
+
+	TObjectPtr<APracticeScoreBoard> PracticeScoreBoardActor;
 };

--- a/SPT/Source/SPT/SPT.Build.cs
+++ b/SPT/Source/SPT/SPT.Build.cs
@@ -19,7 +19,8 @@ public class SPT : ModuleRules
 			Path.Combine(ModuleDirectory, "SpawnVolumes"),
             Path.Combine(ModuleDirectory, "Inventory"),
 			Path.Combine(ModuleDirectory, "UserWidget"),
-            Path.Combine(ModuleDirectory, "PatrolRoutes")
+            Path.Combine(ModuleDirectory, "PatrolRoutes"),
+            Path.Combine(ModuleDirectory, "Actors")
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG",


### PR DESCRIPTION
플레이어가 특정 위치에서 오버랩 될 시 AI가 스폰되며, 시간 안에 AI를 많이 잡는 기능 시작

오버랩을 나갔을 경우 스폰된 AI 제거 및 남은 시간 0으로 변경
시간 제한이 끝났을 경우 스폰된 AI 제거
점수는 훈련 재시작시에만 갱신되도록 구현