### PR TITLE
[update] 총 장착한 상태에 따라 애니메이션과 UI가 동작하도록 수정

### DIFF
--- a/SPT/Content/Blueprints/Animations/ABP_SPTPlayerAnimInstance.uasset
+++ b/SPT/Content/Blueprints/Animations/ABP_SPTPlayerAnimInstance.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:092a7d90eec4fc6600e51031c56710687f0ae87a553997694b49821558886a1e
-size 735773
+oid sha256:a4ba7f6737facfaba3a62772b7efb109b64eaeef03dda9f9536866638ec3a33e
+size 777007

--- a/SPT/Source/SPT/AnimInstances/SPTPlayerAnimInstance.cpp
+++ b/SPT/Source/SPT/AnimInstances/SPTPlayerAnimInstance.cpp
@@ -80,7 +80,13 @@ void USPTPlayerAnimInstance::NativeUpdateAnimation(float DeltaSeconds)
 			TurnYaw.Yaw = GetCurveValue(FName("RemainingTurnYaw")) * DeltaSeconds * RotationScalar;
 			Character->AddActorLocalRotation(TurnYaw);
 		}
-		
+
+		if (ASPTPlayerCharacter* SPTPlayerCharacter = Cast<ASPTPlayerCharacter>(Character))
+		{
+			// 현재 플레이어의 무기 종류
+			CurWeaponType = SPTPlayerCharacter->GetEquippedFirearmType();
+		}
+
 	}
 }
 

--- a/SPT/Source/SPT/AnimInstances/SPTPlayerAnimInstance.h
+++ b/SPT/Source/SPT/AnimInstances/SPTPlayerAnimInstance.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Animation/AnimInstance.h"
+#include "Data/WeaponDataStructs.h"
 #include "SPTPlayerAnimInstance.generated.h"
 
 class UCharacterMovementComponent;
@@ -49,4 +50,6 @@ protected:
 	bool bIsFalling;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement Data")
 	bool bIsCrouching;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon Data")
+	EFirearmType CurWeaponType;
 };

--- a/SPT/Source/SPT/SPT.Build.cs
+++ b/SPT/Source/SPT/SPT.Build.cs
@@ -20,7 +20,8 @@ public class SPT : ModuleRules
             Path.Combine(ModuleDirectory, "Inventory"),
 			Path.Combine(ModuleDirectory, "UserWidget"),
             Path.Combine(ModuleDirectory, "PatrolRoutes"),
-            Path.Combine(ModuleDirectory, "Actors")
+            Path.Combine(ModuleDirectory, "Actors"),
+            Path.Combine(ModuleDirectory, "Items")
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG",

--- a/SPT/Source/SPT/UserWidget/PlayerMainHUD.cpp
+++ b/SPT/Source/SPT/UserWidget/PlayerMainHUD.cpp
@@ -5,10 +5,50 @@
 #include "Components/Image.h"
 #include "Components/TextBlock.h"
 #include "Components/CanvasPanel.h"
+#include "SPTPlayerCharacter.h"
+#include "Weapons/WeaponBase.h"
+#include "Data/WeaponDataStructs.h"
+#include "Weapons/FirearmWeapon.h"
 
 void UPlayerMainHUD::NativeOnInitialized()
 {
 	Super::NativeOnInitialized();
+
+	
+}
+
+void UPlayerMainHUD::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+	Super::NativeTick(MyGeometry, InDeltaTime);
+
+	// 가능하다면 틱 말고 델리게이트로 바인딩 하는게 성능에 유리함
+	if (APlayerController* PlayerController = GetOwningPlayer())
+	{
+		ASPTPlayerCharacter* Player = Cast<ASPTPlayerCharacter>(PlayerController->GetPawn());
+		if (Player)
+		{
+			// 장착중이 아니라면
+			if (EFirearmType::EFT_MAX == Player->GetEquippedFirearmType())
+			{
+				AmmoVisibilityUpdate(false);
+			}
+			// 총을 장착중이라면
+			else
+			{
+				AmmoVisibilityUpdate(true);
+
+				if (AFirearmWeapon* FirearmWeapon = Cast<AFirearmWeapon>(Player->GetEquippedWeapon()))
+				{
+					// 전체 탄약 개수
+					int32 MagazinCapacity = FirearmWeapon->GetMagazinCapacity();
+					// 현재 탄약 개수
+					int32 CurrentAmmo = FirearmWeapon->GetCurrentAmmo();
+
+					AmmoUpdate(CurrentAmmo, MagazinCapacity);
+				}
+			}
+		}
+	}
 }
 
 void UPlayerMainHUD::ShowPlayUI()
@@ -37,8 +77,6 @@ void UPlayerMainHUD::HPUpdate(float NewHP, float MaxHP)
 
 void UPlayerMainHUD::AmmoVisibilityUpdate(bool IsVisibility)
 {
-	// 아직 미사용
-	// 총을 장착했는지 확인 후 델리게이트를 사용해서 업데이트 되도록 구현해줘야함
 	if (AmmoUI)
 	{
 		if (IsVisibility)
@@ -54,8 +92,6 @@ void UPlayerMainHUD::AmmoVisibilityUpdate(bool IsVisibility)
 
 void UPlayerMainHUD::AmmoUpdate(int NewAmmouCount, int MaxAmmouCount)
 {
-	// 아직 미사용
-	// 총을 장착했는지 확인 후 델리게이트를 사용해서 업데이트 되도록 구현해줘야함
 	if (MagAmmo)
 	{
 		MagAmmo->SetText(FText::FromString(FString::Printf(TEXT("%d"), NewAmmouCount)));

--- a/SPT/Source/SPT/UserWidget/PlayerMainHUD.h
+++ b/SPT/Source/SPT/UserWidget/PlayerMainHUD.h
@@ -18,8 +18,12 @@ class SPT_API UPlayerMainHUD : public UUserWidget
 public:
 	virtual void NativeOnInitialized() override;
 
+protected:
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
 ///////////////////////////////////////////////////////////////////////
 // Play UI
+public:
 	UFUNCTION()
 	void ShowPlayUI();
 


### PR DESCRIPTION
플레이어 캐릭터에서 반환하는 무기 장착 타입으로 애니메이션의 재생 종류를 변경하도록 수정
애니메이션 인스턴스에서 매 틱마다 EFirearmType를 가져오도록 구현
EFirearmType을 기준으로 애니메이션의 재생 종류를 변경하도록 구현

총 장착 상태에 따라 UI가 표시되도록 구현
총을 장착 중일 경우 남은 탄과 최대 탄이 표시되도록 구현